### PR TITLE
Fix dark theme text

### DIFF
--- a/luci-app-ssclash/rootfs/www/luci-static/resources/view/ssclash/settings.js
+++ b/luci-app-ssclash/rootfs/www/luci-static/resources/view/ssclash/settings.js
@@ -861,7 +861,7 @@ function createKernelDownloadSection() {
 
     const statusContainer = E('div', {
         'id': 'kernel-status',
-        'style': 'margin: 15px 0; padding: 12px; border: 1px solid #ddd; border-radius: 4px; background: #f9f9f9;'
+        'style': 'margin: 15px 0; padding: 12px; border: 1px solid #ddd; border-radius: 4px; background: #f9f9f9; color: ' + LIGHT_PANEL_TEXT + ';'
     });
 
     container.appendChild(statusContainer);
@@ -887,7 +887,7 @@ function createKernelDownloadSection() {
                 statusHTML += `<div style="margin-top: 5px;">📦 ${_('Version')}: ${status.version}</div>`;
             } else {
                 statusHTML += `<div style="color: #dc3545; font-weight: bold;">❌ ${_('Kernel Status')}: ${_('Not Installed')}</div>`;
-                statusHTML += `<div style="margin-top: 5px; color: #666;">${_('Mihomo kernel binary not found')}</div>`;
+                statusHTML += `<div style="margin-top: 5px; color: ${LIGHT_PANEL_MUTED_TEXT};">${_('Mihomo kernel binary not found')}</div>`;
             }
 
             statusHTML += `<div style="margin-top: 5px;">🏗️ ${_('System Architecture')}: ${arch}</div>`;
@@ -942,6 +942,9 @@ function createKernelDownloadSection() {
 // SECTION: UI component builders
 // =============================================================================
 
+const LIGHT_PANEL_TEXT = '#1f2937';
+const LIGHT_PANEL_MUTED_TEXT = '#4b5563';
+
 function createModeSelector(currentMode) {
     const container = E('div', { 'class': 'cbi-section' });
 
@@ -957,14 +960,14 @@ function createModeSelector(currentMode) {
 
     const excludeLabel = E('label', {
         'for': 'mode_exclude',
-        'style': 'display: block; padding: 12px; border: 2px solid #ddd; border-radius: 6px; margin-bottom: 10px; cursor: pointer; background: white;'
+        'style': 'display: block; padding: 12px; border: 2px solid #ddd; border-radius: 6px; margin-bottom: 10px; cursor: pointer; background: white; color: ' + LIGHT_PANEL_TEXT + ';'
     }, [
         E('div', { 'style': 'display: flex; align-items: flex-start; gap: 10px;' }, [
             excludeRadio,
             E('div', {}, [
                 E('strong', { 'style': 'display: block; margin-bottom: 5px;' },
                     '⭕ ' + _('Exclude Mode (Universal approach)')),
-                E('div', { 'style': 'color: #666; font-size: 13px; line-height: 1.4;' },
+                E('div', { 'style': 'color: ' + LIGHT_PANEL_MUTED_TEXT + '; font-size: 13px; line-height: 1.4;' },
                     _('Process traffic from ALL interfaces except selected ones. Automatically detects and excludes WAN. Recommended for most users.'))
             ])
         ])
@@ -976,14 +979,14 @@ function createModeSelector(currentMode) {
 
     const explicitLabel = E('label', {
         'for': 'mode_explicit',
-        'style': 'display: block; padding: 12px; border: 2px solid #ddd; border-radius: 6px; cursor: pointer; background: white;'
+        'style': 'display: block; padding: 12px; border: 2px solid #ddd; border-radius: 6px; cursor: pointer; background: white; color: ' + LIGHT_PANEL_TEXT + ';'
     }, [
         E('div', { 'style': 'display: flex; align-items: flex-start; gap: 10px;' }, [
             explicitRadio,
             E('div', {}, [
                 E('strong', { 'style': 'display: block; margin-bottom: 5px;' },
                     '🎯 ' + _('Explicit Mode (Precise control)')),
-                E('div', { 'style': 'color: #666; font-size: 13px; line-height: 1.4;' },
+                E('div', { 'style': 'color: ' + LIGHT_PANEL_MUTED_TEXT + '; font-size: 13px; line-height: 1.4;' },
                     _('Process traffic ONLY from selected interfaces. More secure but requires manual configuration. Recommended for advanced users.'))
             ])
         ])
@@ -1002,13 +1005,17 @@ function createModeSelector(currentMode) {
         if (excludeRadio.checked) {
             excludeLabel.style.borderColor = '#0066cc';
             excludeLabel.style.backgroundColor = '#f0f8ff';
+            excludeLabel.style.color = LIGHT_PANEL_TEXT;
             explicitLabel.style.borderColor = '#ddd';
             explicitLabel.style.backgroundColor = 'white';
+            explicitLabel.style.color = LIGHT_PANEL_TEXT;
         } else if (explicitRadio.checked) {
             explicitLabel.style.borderColor = '#0066cc';
             explicitLabel.style.backgroundColor = '#f0f8ff';
+            explicitLabel.style.color = LIGHT_PANEL_TEXT;
             excludeLabel.style.borderColor = '#ddd';
             excludeLabel.style.backgroundColor = 'white';
+            excludeLabel.style.color = LIGHT_PANEL_TEXT;
         }
     }
 
@@ -1043,7 +1050,7 @@ function createProxyModeSection(currentProxyMode) {
 
     const hint = E('div', {
         'id': 'proxy-mode-hint',
-        'style': 'margin-top: 8px; padding: 10px; border-left: 3px solid #777; border-radius: 3px; font-size: 12px; background: #f9f9f9;'
+        'style': 'margin-top: 8px; padding: 10px; border-left: 3px solid #777; border-radius: 3px; font-size: 12px; background: #f9f9f9; color: ' + LIGHT_PANEL_TEXT + ';'
     });
 
     function updateHint() {
@@ -1107,7 +1114,7 @@ function createTunStackSection(currentTunStack) {
 
     const hint = E('div', {
         'id': 'tun-stack-hint',
-        'style': 'margin-top: 8px; padding: 8px; background: #f9f9f9; border-left: 3px solid #777; border-radius: 3px; font-size: 12px; color: #444;'
+        'style': 'margin-top: 8px; padding: 8px; background: #f9f9f9; border-left: 3px solid #777; border-radius: 3px; font-size: 12px; color: ' + LIGHT_PANEL_TEXT + ';'
     });
 
     function updateHint() {
@@ -1157,7 +1164,7 @@ function createAutoDetectOptions(currentMode, autoDetectLan, autoDetectWan) {
 
     const autoDetectLanLabel = E('label', {
         'for': 'auto_detect_lan',
-        'style': 'display: flex; align-items: center; gap: 8px; padding: 10px; border: 1px solid #ddd; border-radius: 4px; background: #f9f9f9; cursor: pointer;'
+        'style': 'display: flex; align-items: center; gap: 8px; padding: 10px; border: 1px solid #ddd; border-radius: 4px; background: #f9f9f9; color: ' + LIGHT_PANEL_TEXT + '; cursor: pointer;'
     }, [
         autoDetectLanCheckbox,
         E('span', '🔍 ' + _('Automatically detect LAN bridge interface'))
@@ -1179,7 +1186,7 @@ function createAutoDetectOptions(currentMode, autoDetectLan, autoDetectWan) {
 
     const autoDetectWanLabel = E('label', {
         'for': 'auto_detect_wan',
-        'style': 'display: flex; align-items: center; gap: 8px; padding: 10px; border: 1px solid #ddd; border-radius: 4px; background: #f9f9f9; cursor: pointer;'
+        'style': 'display: flex; align-items: center; gap: 8px; padding: 10px; border: 1px solid #ddd; border-radius: 4px; background: #f9f9f9; color: ' + LIGHT_PANEL_TEXT + '; cursor: pointer;'
     }, [
         autoDetectWanCheckbox,
         E('span', '🔍 ' + _('Automatically detect WAN interface'))
@@ -1212,6 +1219,7 @@ function createAutoDetectOptions(currentMode, autoDetectLan, autoDetectWan) {
                     const label = checkbox.nextElementSibling;
                     label.style.borderColor = '#ccc';
                     label.style.backgroundColor = 'white';
+                    label.style.color = LIGHT_PANEL_TEXT;
 
                     const autoIndicator = label.querySelector('.auto-indicator');
                     if (autoIndicator) {
@@ -1277,12 +1285,15 @@ function createInterfaceSelector(interfaces, selectedInterfaces, currentMode) {
         if (isAutoDetected) {
             label.style.borderColor = '#28a745';
             label.style.backgroundColor = '#f8fff8';
+            label.style.color = LIGHT_PANEL_TEXT;
         } else if (checkbox.checked) {
             label.style.borderColor = '#0066cc';
             label.style.backgroundColor = '#e6f3ff';
+            label.style.color = LIGHT_PANEL_TEXT;
         } else {
             label.style.borderColor = '#ccc';
             label.style.backgroundColor = 'white';
+            label.style.color = LIGHT_PANEL_TEXT;
         }
     }
 
@@ -1297,11 +1308,11 @@ function createInterfaceSelector(interfaces, selectedInterfaces, currentMode) {
 
             const groupContainer = E('div', {
                 'class': 'cbi-section',
-                'style': 'margin-bottom: 5px; border: 1px solid #ddd; border-radius: 4px; padding: 0 8px 8px 8px; background-color: #f9f9f9;'
+                'style': 'margin-bottom: 5px; border: 1px solid #ddd; border-radius: 4px; padding: 0 8px 8px 8px; background-color: #f9f9f9; color: ' + LIGHT_PANEL_TEXT + ';'
             });
 
             const groupTitle = E('h4', {
-                'style': 'color: #555; font-size: 13px;'
+                'style': 'color: ' + LIGHT_PANEL_TEXT + '; font-size: 13px;'
             }, categoryNames[category] || category);
 
             groupContainer.appendChild(groupTitle);
@@ -1321,7 +1332,7 @@ function createInterfaceSelector(interfaces, selectedInterfaces, currentMode) {
 
                 const label = E('label', {
                     'for': 'iface_' + iface.name,
-                    'style': 'display: flex; align-items: center; padding: 6px 6px 6px 24px; border: 1px solid #ccc; border-radius: 3px; cursor: pointer; background-color: white; transition: all 0.15s ease; font-size: 13px; min-height: 32px; position: relative; line-height: 1.2;'
+                    'style': 'display: flex; align-items: center; padding: 6px 6px 6px 24px; border: 1px solid #ccc; border-radius: 3px; cursor: pointer; background-color: white; color: ' + LIGHT_PANEL_TEXT + '; transition: all 0.15s ease; font-size: 13px; min-height: 32px; position: relative; line-height: 1.2;'
                 }, [
                     E('span', { 'style': 'margin-right: 6px; font-size: 14px; flex-shrink: 0;' }, iface.icon),
                     E('span', { 'style': 'font-weight: 500; flex-grow: 1;' }, iface.description)
@@ -1378,9 +1389,9 @@ function createAdditionalSettings(blockQuic, useTmpfsRules, enableHwid, hwidUser
         'style': 'display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 10px 14px; margin: 15px 0;'
     });
 
-    const cardStyle = 'display: flex; flex-direction: column; gap: 6px; padding: 10px 12px; border: 1px solid #ddd; border-radius: 4px; background: #f9f9f9; cursor: pointer;';
+    const cardStyle = 'display: flex; flex-direction: column; gap: 6px; padding: 10px 12px; border: 1px solid #ddd; border-radius: 4px; background: #f9f9f9; color: ' + LIGHT_PANEL_TEXT + '; cursor: pointer;';
     const cardHeaderStyle = 'display: flex; align-items: center; gap: 8px;';
-    const cardDescStyle = 'font-size: 11px; color: #666; line-height: 1.35;';
+    const cardDescStyle = 'font-size: 11px; color: ' + LIGHT_PANEL_MUTED_TEXT + '; line-height: 1.35;';
 
     const blockQuicCheckbox = E('input', {
         'type': 'checkbox',
@@ -1446,7 +1457,7 @@ function createAdditionalSettings(blockQuic, useTmpfsRules, enableHwid, hwidUser
 
     const hwidAdvancedContainer = E('div', {
         'id': 'hwid_advanced',
-        'style': 'display: none; padding: 10px 12px; border: 1px solid #ddd; border-radius: 4px; background: #fff; margin-top: 10px;'
+        'style': 'display: none; padding: 10px 12px; border: 1px solid #ddd; border-radius: 4px; background: #fff; color: ' + LIGHT_PANEL_TEXT + '; margin-top: 10px;'
     });
 
     const hwidFieldsGrid = E('div', {
@@ -1481,7 +1492,7 @@ function createAdditionalSettings(blockQuic, useTmpfsRules, enableHwid, hwidUser
     ]);
 
     const hwidHint = E('div', {
-        'style': 'font-size: 11px; color: #666; margin-top: 8px;'
+        'style': 'font-size: 11px; color: ' + LIGHT_PANEL_MUTED_TEXT + '; margin-top: 8px;'
     }, _('Values sent in HTTP headers of proxy-provider requests (User-Agent / x-device-os).'));
 
     hwidAdvancedContainer.appendChild(hwidFieldsGrid);
@@ -1521,6 +1532,7 @@ async function updateInterfaceCheckboxes(newMode) {
             const label = cb.nextElementSibling;
             label.style.borderColor = '#ccc';
             label.style.backgroundColor = 'white';
+            label.style.color = LIGHT_PANEL_TEXT;
 
             const autoIndicator = label.querySelector('.auto-indicator');
             if (autoIndicator) {
@@ -1537,6 +1549,7 @@ async function updateInterfaceCheckboxes(newMode) {
                 if (autoDetectEnabled && ifaceName === detectedInterface) {
                     label.style.borderColor = '#28a745';
                     label.style.backgroundColor = '#f8fff8';
+                    label.style.color = LIGHT_PANEL_TEXT;
 
                     const autoIndicator = E('span', {
                         'class': 'auto-indicator',
@@ -1546,6 +1559,7 @@ async function updateInterfaceCheckboxes(newMode) {
                 } else {
                     label.style.borderColor = '#0066cc';
                     label.style.backgroundColor = '#e6f3ff';
+                    label.style.color = LIGHT_PANEL_TEXT;
                 }
             }
         });
@@ -1769,6 +1783,7 @@ return view.extend({
                     const label = cb.nextElementSibling;
                     label.style.borderColor = '#ccc';
                     label.style.backgroundColor = 'white';
+                    label.style.color = LIGHT_PANEL_TEXT;
                 });
             }
         }, _('Clear All Interfaces'));
@@ -1792,9 +1807,11 @@ return view.extend({
                         if (cb.checked) {
                             label.style.borderColor = '#0066cc';
                             label.style.backgroundColor = '#e6f3ff';
+                            label.style.color = LIGHT_PANEL_TEXT;
                         } else {
                             label.style.borderColor = '#ccc';
                             label.style.backgroundColor = 'white';
+                            label.style.color = LIGHT_PANEL_TEXT;
                         }
                     });
 
@@ -1810,6 +1827,7 @@ return view.extend({
                                 const detectedLabel = detectedCheckbox.nextElementSibling;
                                 detectedLabel.style.borderColor = '#28a745';
                                 detectedLabel.style.backgroundColor = '#f8fff8';
+                                detectedLabel.style.color = LIGHT_PANEL_TEXT;
 
                                 const existingIndicator = detectedLabel.querySelector('.auto-indicator');
                                 if (!existingIndicator) {
@@ -1831,9 +1849,11 @@ return view.extend({
                                 if (detectedCheckbox.checked) {
                                     detectedLabel.style.borderColor = '#0066cc';
                                     detectedLabel.style.backgroundColor = '#e6f3ff';
+                                    detectedLabel.style.color = LIGHT_PANEL_TEXT;
                                 } else {
                                     detectedLabel.style.borderColor = '#ccc';
                                     detectedLabel.style.backgroundColor = 'white';
+                                    detectedLabel.style.color = LIGHT_PANEL_TEXT;
                                 }
                             }
                         }

--- a/luci-app-ssclash/rootfs/www/luci-static/resources/view/ssclash/settings.js
+++ b/luci-app-ssclash/rootfs/www/luci-static/resources/view/ssclash/settings.js
@@ -944,6 +944,7 @@ function createKernelDownloadSection() {
 
 const LIGHT_PANEL_TEXT = '#1f2937';
 const LIGHT_PANEL_MUTED_TEXT = '#4b5563';
+const LIGHT_PANEL_INPUT_STYLE = 'background: #fff; color: ' + LIGHT_PANEL_TEXT + '; border-color: #93c5fd;';
 
 function createModeSelector(currentMode) {
     const container = E('div', { 'class': 'cbi-section' });
@@ -1473,7 +1474,8 @@ function createAdditionalSettings(blockQuic, useTmpfsRules, enableHwid, hwidUser
                 'id': 'hwid_user_agent',
                 'class': 'cbi-input-text',
                 'value': hwidUserAgent || 'SSClash',
-                'placeholder': 'SSClash'
+                'placeholder': 'SSClash',
+                'style': LIGHT_PANEL_INPUT_STYLE
             })
         ]),
         E('div', {}, [
@@ -1486,7 +1488,8 @@ function createAdditionalSettings(blockQuic, useTmpfsRules, enableHwid, hwidUser
                 'id': 'hwid_device_os',
                 'class': 'cbi-input-text',
                 'value': hwidDeviceOS || 'OpenWrt',
-                'placeholder': 'OpenWrt'
+                'placeholder': 'OpenWrt',
+                'style': LIGHT_PANEL_INPUT_STYLE
             })
         ])
     ]);


### PR DESCRIPTION
## Summary

This PR fixes text visibility issues in the SSClash LuCI settings page when using a dark LuCI theme.

Some SSClash settings controls use light inline backgrounds. In dark themes, text color was inherited from the theme and could become white on a light background, making labels, descriptions, and input values hard to read.

## What changed

- Added explicit dark text colors for light inline panels/cards.
- Fixed text contrast in:
  - interface processing mode cards
  - proxy mode hint
  - TUN stack hint
  - automatic interface detection cards
  - interface selector cards
  - additional settings cards
  - Mihomo kernel status panel
- Added explicit text color for HWID input fields:
  - `User-Agent`
  - `Device OS`
- Kept the fix scoped to LuCI UI styling only.

## Why

The page mixes dark-theme LuCI containers with custom light inline panels. Without explicit text colors, browser/theme inheritance can produce white text on white or near-white backgrounds.

## Tested

- Built a test IPK for OpenWrt 24.10.0 `mediatek/filogic`.
- Installed and tested on OpenWrt One.
- Verified dark theme readability for labels, descriptions, selected text, and typed input values.
